### PR TITLE
CMake build system modifications for fms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ list(APPEND fms_fortran_src_files
 # Collect FMS C source files
 list(APPEND fms_c_src_files
   affinity/affinity.c
+  diag_manager/mppnccombine.c
   mosaic/create_xgrid.c
   mosaic/gradient_c2l.c
   mosaic/interp.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,8 @@ foreach(kind ${kinds})
   target_compile_definitions(${libTgt} PRIVATE "${fms_defs}")
   target_compile_definitions(${libTgt} PRIVATE "${${kind}_defs}")
 
-  target_link_libraries(${libTgt} PUBLIC NetCDF::NetCDF_Fortran
+  target_link_libraries(${libTgt} PUBLIC NetCDF::NetCDF_C
+                                         NetCDF::NetCDF_Fortran
                                          MPI::MPI_Fortran)
 
   if(OpenMP_Fortran_FOUND)


### PR DESCRIPTION
 **Description**

  Two small CMake changes needed by turbo-stack's `find_package(FMS)` consumer:

  1. Add `diag_manager/mppnccombine.c` to the cmake C source list (was already in the makefile build).
  2. Add `NetCDF::NetCDF_C` to the PUBLIC link interface of `fms_r4` and `fms_r8`. Without it, downstream consumers see only `NetCDF::NetCDF_Fortran` + bare `-lnetcdf` flags from `nf-config --flibs`, which fail to resolve at link time on NetCDF installs with split `lib`/`lib64` layouts (e.g. NCAR Derecho's NetCDF module).

  This is part of the issue-192 cross-repo CMake build-system effort:

  | Repo | PR | Base |
  |---|---|---|
  | **FMS** | **this PR** | `dev/turbo` |
  | TIM | TURBO-ESM/TIM#16 | `main` |
  | MOM6 | TURBO-ESM/MOM6#25 | `dev/turbo` |
  | turbo-stack | TURBO-ESM/turbo-stack#233 | `main` |

  **Recommended merge order**: FMS → TIM → MOM6 → turbo-stack. turbo-stack consumes the other three via
  `find_package(FMS|TIM)` and `add_subdirectory(${MOM6_SOURCE_DIR} ...)`.

  **How Has This Been Tested?**

  Exercised end-to-end via the turbo-stack PR, which builds FMS2 from this branch and then links MOM6 against `FMS::fms_r8`.
